### PR TITLE
Fix metadata step silently failing

### DIFF
--- a/IntentsExt/Focus/FocusItem.swift
+++ b/IntentsExt/Focus/FocusItem.swift
@@ -16,7 +16,7 @@ struct FocusItem: Identifiable, Hashable, Equatable, Codable, @unchecked Sendabl
 @available(iOS 16.0, *)
 extension FocusItem: AppEntity {
   static var typeDisplayRepresentation: TypeDisplayRepresentation {
-    TypeDisplayRepresentation(stringLiteral: "FocusItem")
+    "FocusItem"
   }
   
   static var typeDisplayName: LocalizedStringResource = "FocusItem"


### PR DESCRIPTION
I ran into this same issue and found that Xcode will silently fail on the metadata generation step with this message. The fix is to no longer instantiate `TypeDisplayRepresentation` using `init(stringLiteral)`.

<img width="842" alt="Screen Shot 2022-11-28 at 11 12 15 AM" src="https://user-images.githubusercontent.com/70799/204361220-8ca9870d-5389-4266-835b-bd8663a87365.png">
